### PR TITLE
WIP: add movie images to the oval Drawables

### DIFF
--- a/app/src/main/java/com/lucasbrandt/movieselector/MainActivity.kt
+++ b/app/src/main/java/com/lucasbrandt/movieselector/MainActivity.kt
@@ -10,6 +10,7 @@ import com.google.gson.Gson
 import com.lucasbrandt.movieselector.databinding.ActivityMainBinding
 import com.lucasbrandt.movieselector.network.MovieDataModel
 
+
 class MainActivity : AppCompatActivity() {
 
     lateinit var binding: ActivityMainBinding

--- a/app/src/main/java/com/lucasbrandt/movieselector/MovieAdapter.kt
+++ b/app/src/main/java/com/lucasbrandt/movieselector/MovieAdapter.kt
@@ -1,26 +1,62 @@
 package com.lucasbrandt.movieselector
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.shapes.OvalShape
 import com.lucasbrandt.movieselector.network.MovieDataModel
-import com.lucasbrandt.movieselector.network.MovieDrawable
 import com.lukedeighton.wheelview.adapter.WheelArrayAdapter
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
 
-class MovieAdapter(entries: List<MovieDataModel>?, context: Context) : WheelArrayAdapter<MovieDataModel>(entries) {
+
+class MovieAdapter(val entries: List<MovieDataModel>?, val context: Context) : WheelArrayAdapter<MovieDataModel>(entries) {
+    lateinit var drawable: Array<Drawable>
+
+    val target = object : Target {
+        override fun onBitmapLoaded(bitmap: Bitmap, from: Picasso.LoadedFrom) {
+            drawable = arrayOf(createOvalDrawable(), BitmapDrawable(context.resources, bitmap))
+        }
 
     private val colorArray = context.resources.getIntArray(R.array.ovalColors)
+        override fun onBitmapFailed(errorDrawable: Drawable) {
+            drawable = arrayOf(createOvalDrawable(), errorDrawable)
+        }
+
+        override fun onPrepareLoad(placeHolderDrawable: Drawable) {
+            drawable = arrayOf(createOvalDrawable(), placeHolderDrawable)
+        }
+    }
 
     override fun getDrawable(position: Int): Drawable {
-        val drawable = arrayOf(createOvalDrawable(position), MovieDrawable(position.toString()))
+
+//        val target = object : Target {
+//            override fun onBitmapLoaded(bitmap: Bitmap, from: Picasso.LoadedFrom) {
+//                drawable = arrayOf(createOvalDrawable(), BitmapDrawable(context.resources, bitmap))
+//            }
+//
+//            override fun onBitmapFailed(errorDrawable: Drawable) {
+//                drawable = arrayOf(createOvalDrawable(), errorDrawable)
+//            }
+//
+//            override fun onPrepareLoad(placeHolderDrawable: Drawable) {
+//                drawable = arrayOf(createOvalDrawable(), placeHolderDrawable)
+//            }
+//        }
+
+        Picasso.with(context)
+            .load(IMG_URL + entries?.get(position)?.backdrop_path)
+            .placeholder(R.drawable.placeholder)
+            .error(R.drawable.placeholder)
+            .into(target)
+
         return LayerDrawable(drawable)
     }
 
-    private fun createOvalDrawable(position: Int): Drawable {
-        val shapeDrawable = ShapeDrawable(OvalShape())
-        shapeDrawable.paint.color = colorArray[position]
-        return shapeDrawable
+    private fun createOvalDrawable(): Drawable {
+        return ShapeDrawable(OvalShape())
     }
 }

--- a/app/src/main/java/com/lucasbrandt/movieselector/network/MovieDrawable.kt
+++ b/app/src/main/java/com/lucasbrandt/movieselector/network/MovieDrawable.kt
@@ -25,7 +25,7 @@ class MovieDrawable(val text: String) : Drawable() {
             bounds.centerX() - 15f * text.length,
             bounds.centerY() + 15f,
             paint
-        )
+            )
     }
 
     override fun setAlpha(alpha: Int) {


### PR DESCRIPTION
This is a WIP as I have tried almost every method of transferring drawables from Picasso to the `MovieAdapter`. The remaining code was the best chance at working, but it still failed. I believe this is due to a limitation on the wheel library I chose. The `MovieAdapter` doesn't work exactly like a `ListAdapter` which it tries to behave like. It lacks a a `LayoutManager` implementation that would allow for Views to be passed through the adapter instead of drawables. This would make adding images very simple, but instead I'm left trying hacky things with Picasso implementations.